### PR TITLE
Update macOS download instructions for ARM support

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -451,14 +451,14 @@
             <h2>Download OVERSEE</h2>
             <p>Download the latest version for your operating system:</p>
             <p>* The large red buttons are latest versions!</p>
-            <p>macOS: Binary, you must accept the risk in system settings (google how)!</p>
+            <p>macOS: (Currently ARM only, Intel coming soon.) Binary, you must accept the risk in system settings (google how)!</p>
             <p>Windows: Exe, double click it!</p>
             <p>Linux: Unix executable, chmod +x and ./(name here)!</p>
             
             <div class="download-buttons">
                 <div class="download-dropdown">
                     <a href="#" class="download-button" onclick="return false;" data-platform="macos">
-                        <div class="platform-name">🍎 macOS</div>
+                        <div class="platform-name">🍎 macOS (Arm)</div>
                         <div class="download-stats loading-stats" id="stats-macos">Loading...</div>
                     </a>
                     <div class="download-dropdown-content">


### PR DESCRIPTION
This pull request updates the macOS download information on the `website/index.html` page to clarify platform support and improve user guidance.

User-facing documentation updates:

* Updated the macOS download instructions to specify that only ARM binaries are currently available, with Intel support coming soon.
* Changed the macOS download button label to "🍎 macOS (Arm)" to clearly indicate the supported architecture.